### PR TITLE
Queue requests to reduce the load on database writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,30 @@
 
 ### Unrealeased
 
-* Deliver CSS and JS without asset pipeline
-* Reverse date range when start is after end
-* Add link to external page
-* Display views evolution against previous period
-* List all paths from a host referrer when available
-* Scope css styles with .active-analytics
-* Update colors to augment contrast
-* Add gap to separate days in chart
-* Add link to day on chart label
-* Prevent chart NaN
-* Add trend labels color
-* Remove unused css
+*   Queue requests to reduce the load on database writes
+
+    Database writes are slow. On large trafic applications it might overload the database.
+    The idea is to queue data into redis and to flush periodically into the database.
+
+    ```ruby
+    ActiveAnalytics.queue_request(request) # In an after_action
+    ```
+
+    Then call from time to time :
+
+    ```ruby
+    ActiveAnalytics.flush_queue # From a cron or a job
+    ```
+
+*   Deliver CSS and JS without asset pipeline
+*   Reverse date range when start is after end
+*   Add link to external page
+*   Display views evolution against previous period
+*   List all paths from a host referrer when available
+*   Scope css styles with .active-analytics
+*   Update colors to augment contrast
+*   Add gap to separate days in chart
+*   Add link to day on chart label
+*   Prevent chart NaN
+*   Add trend labels color
+*   Remove unused css

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :development do
   gem 'sqlite3'
+  gem "redis"
 end
 
 # To use a debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       tzinfo (~> 2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)
     erubi (1.12.0)
@@ -138,6 +139,10 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redis (5.0.7)
+      redis-client (>= 0.9.0)
+    redis-client (0.16.0)
+      connection_pool
     sqlite3 (1.4.2)
     thor (1.2.1)
     timeout (0.3.2)
@@ -153,6 +158,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_analytics!
+  redis
   sqlite3
 
 BUNDLED WITH

--- a/app/models/active_analytics/views_per_day.rb
+++ b/app/models/active_analytics/views_per_day.rb
@@ -114,12 +114,13 @@ module ActiveAnalytics
     end
 
     def self.append(params)
+      total = params.delete(:total) || 1
       params[:site] = params[:site].downcase if params[:site]
       params[:page] = params[:page].downcase if params[:page]
       params[:referrer_path] = nil if params[:referrer_path].blank?
       params[:referrer_path] = params[:referrer_path].downcase if params[:referrer_path]
       params[:referrer_host] = params[:referrer_host].downcase if params[:referrer_host]
-      find_or_create_by!(params) if where(params).update_all("total = total + 1") == 0
+      where(params).first.try(:increment!, :total, total) || create!(params.merge(total: total))
     end
   end
 end

--- a/app/models/active_analytics/views_per_day.rb
+++ b/app/models/active_analytics/views_per_day.rb
@@ -122,5 +122,17 @@ module ActiveAnalytics
       params[:referrer_host] = params[:referrer_host].downcase if params[:referrer_host]
       where(params).first.try(:increment!, :total, total) || create!(params.merge(total: total))
     end
+
+    SLASH = "/"
+
+    def self.split_referrer(referrer)
+      return [nil, nil] if referrer.blank?
+      if (uri = URI(referrer)).host.present?
+        [uri.host, uri.path.presence]
+      else
+        strings = referrer.split(SLASH, 2)
+        [strings[0], strings[1] ? SLASH + strings[1] : nil]
+      end
+    end
   end
 end

--- a/lib/active_analytics.rb
+++ b/lib/active_analytics.rb
@@ -2,6 +2,22 @@ require "active_analytics/version"
 require "active_analytics/engine"
 
 module ActiveAnalytics
+  def self.redis_url=(string)
+    @redis_url = string
+  end
+
+  def self.redis_url
+    @redis_url ||= ENV["REDIS_URL"] || "redis://localhost"
+  end
+
+  def self.redis=(connection)
+    @redis = connection
+  end
+
+  def self.redis
+    @redis ||= Redis.new(url: redis_url)
+  end
+
   def self.record_request(request)
     params = {
       site: request.host,
@@ -21,5 +37,29 @@ module ActiveAnalytics
       Rails.logger.error(ex.inspect)
       Rails.logger.error(ex.backtrace.join("\n"))
     end
+  end
+
+  QUEUE = "ActiveAnalytics::Queue"
+  OLD_QUEUE = "ActiveAnalytics::OldQueue"
+
+  def self.queue_request(request)
+    keys = [request.host, request.path]
+    if request.referrer.present?
+      referrer = URI(request.referrer)
+      keys << referrer.host << referrer.path
+    end
+    redis.hincrby(QUEUE, keys.join("|").downcase, 1)
+  end
+
+  def self.flush_queue
+    return if !redis.exists?(QUEUE)
+    cursor = 0
+    date = Date.today
+    redis.rename(QUEUE, OLD_QUEUE)
+    redis.hscan_each(OLD_QUEUE) do |key, count|
+      site, page, referrer_host, referrer_path = key.split("|")
+      ViewsPerDay.append(date: date, site: site, page: page, referrer_host: referrer_host, referrer_path: referrer_path, total: count.to_i)
+    end
+    redis.del(OLD_QUEUE)
   end
 end

--- a/test/active_analytics_test.rb
+++ b/test/active_analytics_test.rb
@@ -1,13 +1,11 @@
 require "test_helper"
+require "redis"
 
 class ActiveAnalyticsTest < ActiveSupport::TestCase
   Request = Struct.new(:host, :path, :referrer)
 
   def test_record_request_with_referrer
-    req1 = Request.new("site.test", "page", "http://site.test/previous_page")
-    req2 = Request.new("SITE.TEST", "PAGE", "http://SITE.TEST/PREVIOUS_PAGE")
-    req3 = Request.new("site.test", "page", "http://site.test/")
-    req4 = Request.new("site.test", "page", "http://site.test")
+    req1, req2, req3, req4 = sample_requests
 
     assert_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req1) }
     assert_no_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req2) }
@@ -22,5 +20,40 @@ class ActiveAnalyticsTest < ActiveSupport::TestCase
     assert_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req1) }
     assert_no_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req2) }
     assert_equal(2, ActiveAnalytics::ViewsPerDay.last.total)
+  end
+
+  def test_queue_request_and_flush_queue
+    req1, req2, req3, req4 = sample_requests
+    ActiveAnalytics.redis.del("ActiveAnalytics::Queue")
+    ActiveAnalytics.redis.del("ActiveAnalytics::OldQueue")
+
+    ActiveAnalytics.queue_request(req1)
+    ActiveAnalytics.queue_request(req2)
+    ActiveAnalytics.queue_request(req3)
+    ActiveAnalytics.queue_request(req4)
+
+    assert_equal(3, ActiveAnalytics.redis.hlen("ActiveAnalytics::Queue"), ActiveAnalytics.redis.hgetall("ActiveAnalytics::Queue"))
+    assert_difference("ActiveAnalytics::ViewsPerDay.count", 3) { ActiveAnalytics.flush_queue; }
+    assert_equal(2, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "page", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+    assert_equal(0, ActiveAnalytics.redis.exists("ActiveAnalytics::Queue"))
+    assert_equal(0, ActiveAnalytics.redis.exists("ActiveAnalytics::OldQueue"))
+    assert_no_difference("ActiveAnalytics::ViewsPerDay.sum(:total)") { ActiveAnalytics.flush_queue; }
+
+    ActiveAnalytics.queue_request(req1)
+    assert_difference("ActiveAnalytics::ViewsPerDay.sum(:total)", 1) do
+      assert_no_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.flush_queue; }
+    end
+    assert_equal(3, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "page", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+  end
+
+  private
+
+  def sample_requests
+    [
+      Request.new("site.test", "page", "http://site.test/previous_page"),
+      Request.new("SITE.TEST", "PAGE", "http://SITE.TEST/PREVIOUS_PAGE"),
+      Request.new("site.test", "page", "http://site.test/"),
+      Request.new("site.test", "page", "http://site.test"),
+    ]
   end
 end

--- a/test/models/active_analytics/views_per_day_test.rb
+++ b/test/models/active_analytics/views_per_day_test.rb
@@ -17,5 +17,17 @@ module ActiveAnalytics
       assert_equal(Date.tomorrow, histogram.bars[2].label)
       assert_equal(0, histogram.bars[2].value)
     end
+
+    def test_split_referrer
+      assert_equal([nil, nil], ViewsPerDay.split_referrer(nil))
+      assert_equal([nil, nil], ViewsPerDay.split_referrer(""))
+      assert_equal(["domain.test", nil], ViewsPerDay.split_referrer("domain.test"))
+      assert_equal(["domain.test", "/1"], ViewsPerDay.split_referrer("domain.test/1"))
+      assert_equal(["domain.test", "/1/2"], ViewsPerDay.split_referrer("domain.test/1/2"))
+      assert_equal(["domain.test", nil], ViewsPerDay.split_referrer("https://domain.test"))
+      assert_equal(["domain.test", "/"], ViewsPerDay.split_referrer("https://domain.test/"))
+      assert_equal(["domain.test", "/1"], ViewsPerDay.split_referrer("https://domain.test/1"))
+      assert_equal(["domain.test", "/1/2"], ViewsPerDay.split_referrer("https://domain.test/1/2"))
+    end
   end
 end


### PR DESCRIPTION
Database writes are slow. On large trafic applications it might overload the database. The idea is to queue data into redis and to flush periodically into the database.