### PR TITLE
feat #6: Track number of requests per user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ authenticate :user, -> (u) { u.admin? } do # Supposing there is a User#admin? me
 end
 ```
 
+## Development
+
+The tests require redis to run. You can fire up a service using `docker run -p 6379:6379 redis`.
+
 ## License
 The gem is available as open-source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 

--- a/active_analytics.gemspec
+++ b/active_analytics.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", ">= 5.2.0"
+  spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "browser", ">= 5.3.1"
 end

--- a/db/migrate/20240228141003_add_user_agent_to_views_per_days.rb
+++ b/db/migrate/20240228141003_add_user_agent_to_views_per_days.rb
@@ -1,0 +1,15 @@
+class AddUserAgentToViewsPerDays < ActiveRecord::Migration[6.0]
+  def change
+    add_column :active_analytics_views_per_days, :device_type, :string
+    add_column :active_analytics_views_per_days, :operating_system, :string
+    add_column :active_analytics_views_per_days, :browser, :string
+
+    remove_column :active_analytics_views_per_days, :created_at, :datetime
+    remove_column :active_analytics_views_per_days, :updated_at, :datetime
+
+    add_index :active_analytics_views_per_days,
+              [:date, :site, :page, :referrer_path, :referrer_host, :browser, :device_type, :operating_system],
+              name: "index_active_analytics_views_per_days_on_user_agent_and_date",
+              unique: true
+  end
+end

--- a/lib/active_analytics.rb
+++ b/lib/active_analytics.rb
@@ -1,3 +1,5 @@
+require "browser"
+
 require "active_analytics/version"
 require "active_analytics/engine"
 
@@ -18,15 +20,36 @@ module ActiveAnalytics
     @redis ||= Redis.new(url: redis_url)
   end
 
-  def self.record_request(request)
-    params = {
-      site: request.host,
-      page: request.path,
-      date: Date.today,
+  def self.user_agent_extractors
+    @@user_agent_extractors ||= {
+      browser: lambda do |b|
+        return :firefox if b.firefox?
+        return :chrome if b.chrome?
+        return :edge if b.edge?
+        return :safari if b.safari?
+        ""
+      end,
+      device_type: lambda do |b|
+        return :tablet if b.device.tablet?
+        return :mobile if b.device.mobile?
+        # No `desktop?` built in :(
+        # https://github.com/fnando/browser/issues/297#issuecomment-294387382
+        return :desktop if b.platform.windows? || b.platform.linux? || b.platform.mac?
+        ""
+      end,
+      operating_system: lambda do |b|
+        return :windows if b.platform.windows?
+        return :android if b.platform.android?
+        return :linux if b.platform.linux?
+        return :ios if b.platform.ios?
+        return :mac if b.platform.mac?
+        ""
+      end,
     }
-    if request.referrer.present?
-      params[:referrer_host], params[:referrer_path] = ViewsPerDay.split_referrer(request.referrer)
-    end
+  end
+
+  def self.record_request(request)
+    params = self.build_storable_hash(request)
     ViewsPerDay.append(params)
   rescue => ex
     if Rails.env.development? || Rails.env.test?
@@ -37,27 +60,44 @@ module ActiveAnalytics
     end
   end
 
-  SEPARATOR = "|"
   QUEUE = "ActiveAnalytics::Queue"
   OLD_QUEUE = "ActiveAnalytics::OldQueue"
 
   def self.queue_request(request)
-    keys = [request.host, request.path]
-    if request.referrer.present?
-      keys.concat(ViewsPerDay.split_referrer(request.referrer))
-    end
-    redis.hincrby(QUEUE, keys.join(SEPARATOR).downcase, 1)
+    params = self.build_storable_hash(request)
+    key = Rack::Utils.build_nested_query(params)
+    redis.hincrby(QUEUE, key.downcase, 1)
   end
 
   def self.flush_queue
     return if !redis.exists?(QUEUE)
-    cursor = 0
     date = Date.today
     redis.rename(QUEUE, OLD_QUEUE)
     redis.hscan_each(OLD_QUEUE) do |key, count|
-      site, page, referrer_host, referrer_path = key.split(SEPARATOR)
-      ViewsPerDay.append(date: date, site: site, page: page, referrer_host: referrer_host, referrer_path: referrer_path, total: count.to_i)
+      args = Rack::Utils.parse_nested_query(key).symbolize_keys
+      ViewsPerDay.append(**(args.merge(total: count)))
     end
     redis.del(OLD_QUEUE)
+  end
+
+  def self.build_storable_hash(request)
+    params = {
+      site: request.host,
+      page: request.path,
+      date: Date.today,
+    }
+    if request.referrer.present?
+      params[:referrer_host], params[:referrer_path] = ViewsPerDay.split_referrer(request.referrer)
+    end
+
+    user_agent_columns = ViewsPerDay.user_agent_columns
+    if user_agent_columns.any?
+      browser = Browser.new(request.user_agent || "")
+      user_agent_columns.each do |attribute|
+        params[attribute] = self.user_agent_extractors[attribute].call(browser)
+      end
+    end
+
+    params
   end
 end

--- a/lib/active_analytics/version.rb
+++ b/lib/active_analytics/version.rb
@@ -1,3 +1,3 @@
 module ActiveAnalytics
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/test/active_analytics_test.rb
+++ b/test/active_analytics_test.rb
@@ -2,7 +2,14 @@ require "test_helper"
 require "redis"
 
 class ActiveAnalyticsTest < ActiveSupport::TestCase
-  Request = Struct.new(:host, :path, :referrer)
+  Request = Struct.new(:host, :path, :referrer, :user_agent)
+
+  def test_record_request_with_identical
+    req = Request.new("site.test", "page", "http://site.test")
+
+    assert_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req) }
+    assert_no_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.record_request(req) }
+  end
 
   def test_record_request_with_referrer
     req1, req2, req3, req4 = sample_requests
@@ -34,7 +41,9 @@ class ActiveAnalyticsTest < ActiveSupport::TestCase
 
     assert_equal(3, ActiveAnalytics.redis.hlen("ActiveAnalytics::Queue"), ActiveAnalytics.redis.hgetall("ActiveAnalytics::Queue"))
     assert_difference("ActiveAnalytics::ViewsPerDay.count", 3) { ActiveAnalytics.flush_queue; }
-    assert_equal(2, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "page", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+    assert_equal(2, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "fst", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+    assert_equal(1, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "snd", referrer_host: "site.test", referrer_path: "/").first.total)
+    assert_equal(1, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "thrd", referrer_host: "site.test", referrer_path: "").first.total)
     assert_equal(0, ActiveAnalytics.redis.exists("ActiveAnalytics::Queue"))
     assert_equal(0, ActiveAnalytics.redis.exists("ActiveAnalytics::OldQueue"))
     assert_no_difference("ActiveAnalytics::ViewsPerDay.sum(:total)") { ActiveAnalytics.flush_queue; }
@@ -43,17 +52,54 @@ class ActiveAnalyticsTest < ActiveSupport::TestCase
     assert_difference("ActiveAnalytics::ViewsPerDay.sum(:total)", 1) do
       assert_no_difference("ActiveAnalytics::ViewsPerDay.count") { ActiveAnalytics.flush_queue; }
     end
-    assert_equal(3, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "page", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+    assert_equal(3, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "fst", referrer_host: "site.test", referrer_path: "/previous_page").first.total)
+    assert_equal(1, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "snd", referrer_host: "site.test", referrer_path: "/").first.total)
+    assert_equal(1, ActiveAnalytics::ViewsPerDay.where(site: "site.test", page: "thrd", referrer_host: "site.test", referrer_path: "").first.total)
+  end
+
+  def test_user_agent_request_mobile_firefox_twice
+    ActiveAnalytics.record_request(
+      user_agent_request('Mozilla/5.0 (Android 14; Mobile; LG-M255; rv:123.0) Gecko/123.0 Firefox/123.0')
+    )
+    ActiveAnalytics.record_request(
+      user_agent_request('Mozilla/5.0 (Android 12; Mobile; LG-M255; rv:123.0) Gecko/111.0 Firefox/110.0')
+    )
+
+    view = ActiveAnalytics::ViewsPerDay.first
+    assert_equal 1, ActiveAnalytics::ViewsPerDay.count
+    assert_equal 2, view.total
+    assert_equal "firefox", view.browser
+    assert_equal "mobile", view.device_type
+    assert_equal "android", view.operating_system
+  end
+
+  def test_multiple_user_agent
+    ActiveAnalytics.record_request(
+      user_agent_request('Mozilla/5.0 (iPhone14,3; U; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/19A346 Safari/602.1')
+    )
+    ActiveAnalytics.record_request(
+      user_agent_request('Mozilla/5.0 (Android 12; Mobile; LG-M255; rv:123.0) Gecko/111.0 Firefox/110.0')
+    )
+
+    assert_equal 2, ActiveAnalytics::ViewsPerDay.count
+    assert_equal 1, ActiveAnalytics::ViewsPerDay.first.total
+    assert_equal "safari", ActiveAnalytics::ViewsPerDay.first.browser
+    assert_equal 1, ActiveAnalytics::ViewsPerDay.second.total
+    assert_equal "firefox", ActiveAnalytics::ViewsPerDay.second.browser
   end
 
   private
 
   def sample_requests
     [
-      Request.new("site.test", "page", "http://site.test/previous_page"),
-      Request.new("SITE.TEST", "PAGE", "http://SITE.TEST/PREVIOUS_PAGE"),
-      Request.new("site.test", "page", "http://site.test/"),
-      Request.new("site.test", "page", "http://site.test"),
+      Request.new("site.test", "fst", "http://site.test/previous_page"),
+      Request.new("SITE.TEST", "FST", "http://SITE.TEST/PREVIOUS_PAGE"),
+      Request.new("site.test", "snd", "http://site.test/"),
+      Request.new("site.test", "thrd", "http://site.test"),
     ]
+  end
+
+  def user_agent_request(ua)
+    Request.new("site.test", "page", "http://site.test", ua)
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,16 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_03_094108) do
-
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_141003) do
   create_table "active_analytics_views_per_days", force: :cascade do |t|
     t.string "site", null: false
     t.string "page", null: false
@@ -19,8 +18,10 @@ ActiveRecord::Schema.define(version: 2021_03_03_094108) do
     t.bigint "total", default: 1, null: false
     t.string "referrer_host"
     t.string "referrer_path"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "device_type"
+    t.string "operating_system"
+    t.string "browser"
+    t.index ["date", "site", "page", "referrer_path", "referrer_host", "browser", "device_type", "operating_system"], name: "index_active_analytics_views_per_days_on_user_agent_and_date", unique: true
     t.index ["date"], name: "index_active_analytics_views_per_days_on_date"
     t.index ["referrer_host", "referrer_path", "date"], name: "index_active_analytics_views_per_days_on_referrer_and_date"
     t.index ["site", "page", "date"], name: "index_active_analytics_views_per_days_on_site_and_date"

--- a/test/fixtures/active_analytics/views_per_days.yml
+++ b/test/fixtures/active_analytics/views_per_days.yml
@@ -1,5 +1,0 @@
-rorvswild:
-  site: rorvswild.com
-  page: /
-  date: <%= Date.today %>
-  total: 1


### PR DESCRIPTION
This is a first example on how working with one large table could look like when tracking user agents. Notable things from the top of my head:

* I somewhat attempted to make the new columns optional. If someone doesn't run the migration but updates to this version, everything *should* work as it did before. But I wouldn't know how this could be properly tested.
* Making user agent tracking optional was a little bit annoying for the Redis queuing that I missed initially, as I don't use it. I took the liberty to refactor the serialization and deserialization of such keys but didn't include any migration path because I have no idea how to test this properly. So users would need to drain the queue as part of the migration. I guess this could be salvaged by checking whether the key is in the old format if this feels important.
* Customization of extracted strings is hinted at, but not yet implemented. But this should be mainly a documentation issue, as the code is technically only missing a setter.
* I bumped the minimum Rails version to 6 in order to use SQL upserts. This should be more performant and more secure (for whatever security is needed to track single visits, but hey). This however has an important implication: As in SQL `NULL` is not equal to `NULL` the upsert will only work if all columns have empty strings as default. **This is not yet reflected in the migration.**
* I didn't touch the UI for the moment.