### PR TITLE
ArgumentError: Index name is too long (limit: 64 characters) when running rails db:migrate

### DIFF
--- a/db/migrate/20210303094108_create_active_analytics_views_per_days.rb
+++ b/db/migrate/20210303094108_create_active_analytics_views_per_days.rb
@@ -10,7 +10,8 @@ class CreateActiveAnalyticsViewsPerDays < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     add_index :active_analytics_views_per_days, [:date, :site, :page]
-    add_index :active_analytics_views_per_days, [:date, :site, :referrer_host, :referrer_path]
+    add_index :active_analytics_views_per_days, [:date, :site, :referrer_host, :referrer_path],
+              name: 'index_views_per_days_on_date_site_referrer_host_referrer_path'
   end
 
   def down


### PR DESCRIPTION
When trying to install and run the migrations for the active_analytics gem, an error occurs due to the index name exceeding the 64-character limit during rails db:migrate.

### Steps to reproduce:

> 1. Add the active_analytics gem to the Gemfile and run bundle install
> 2. Run rails active_analytics:install:migrations
> 3. Execute rails db:migrate

### Error encountered:

> == 20250309045816 CreateActiveAnalyticsViewsPerDays: migrating ================
> -- create_table(:active_analytics_views_per_days)
>    -> 0.0040s
> -- add_index(:active_analytics_views_per_days, [:date, :site, :page], {:name=>"index_active_analytics_views_per_days_on_date_and_site_and_page"})
>    -> 0.0018s
> -- add_index(:active_analytics_views_per_days, [:date, :site, :referrer_host, :referrer_path], {:name=>"index_active_analytics_views_per_days_on_date_and_site_and_referrer_host_and_referrer_path"})
> bin/rails aborted!
> StandardError: An error has occurred, this and all later migrations canceled: (StandardError)
> 
> Index name 'index_active_analytics_views_per_days_on_date_and_site_and_referrer_host_and_referrer_path' on table 'active_analytics_views_per_days' is too long; the limit is 64 characters


### Environment:
Ruby: ruby 3.2.4 (2024-04-23 revision af471c0e01) [arm64-darwin23]
Rails: Rails 7.1.5.1
Database: PostgreSQL 14.15 (Homebrew)
active_analytics gem version: 0.4.0
	
### Possible solution:

The issue occurs because the index name exceeds the 64-character limit. A possible solution is to modify the migration file to use shorter index names.